### PR TITLE
Add command line flags to parse.py

### DIFF
--- a/scripts/known_field_data/fieldvalues.csv
+++ b/scripts/known_field_data/fieldvalues.csv
@@ -15,6 +15,7 @@
 8666,Light Voice
 1683,Light Class
 7401,Spinfusor
+7461,Thumper
 7385,Assault Rifle
 7384,Arx Buster
 7416,Grenade Launcher

--- a/scripts/parse.py
+++ b/scripts/parse.py
@@ -534,21 +534,6 @@ def indentandrawoffset2globaloffset(indent: bool, rawoffset: int, offsetlist: Li
     raise RuntimeError('There\'s a bug in this code. This statement should not have been reached.')
 
 
-# @click.command()
-# @click.argument('file')
-# @click.option('--disable-id-annotations', is_flag=True,
-#               help='disable printing annotations for enumfield ids')
-# @click.option('--disable-value-annotations', is_flag=True,
-#               help='disable printing annotations for enumfield values')
-# @click.option('--id-annotation-sources', multiple=True,
-#               help='list of additional CSVs to source enumfield id annotations from')
-# @click.option('--value-annotation-sources', multiple=True,
-#               help='list of additional CSVs to source enumfield value annotations from')
-# def run_parse(file: str, disable_id_annotations: bool, disable_value_annotations: bool,
-#               id_annotation_sources: List[str], value_annotation_sources: List[str]) -> None:
-#     pass
-
-
 class CliArguments(NamedTuple):
     file: str
     disable_id_annotations: bool

--- a/scripts/parse.py
+++ b/scripts/parse.py
@@ -29,14 +29,14 @@ K = TypeVar('K')
 V = TypeVar('V')
 
 
-def merge_value_dicts(ds: List[Dict[K, Set[V]]]) -> Dict[K, Set[V]]:
-    r = dict()
-    for d in ds:
-        for k, vset in d.items():
-            if k not in r:
-                r[k] = set()
-            r[k].update(vset)
-    return r
+def merge_value_dicts(dict_list: List[Dict[K, Set[V]]]) -> Dict[K, Set[V]]:
+    result_dict = dict()
+    for dictionary in dict_list:
+        for key, value_set in dictionary.items():
+            if key not in result_dict:
+                result_dict[key] = set()
+                result_dict[key].update(value_set)
+    return result_dict
 
 
 def indentlevel2string(i: int) -> str:

--- a/scripts/parse.py
+++ b/scripts/parse.py
@@ -535,7 +535,7 @@ def indentandrawoffset2globaloffset(indent: bool, rawoffset: int, offsetlist: Li
 
 
 @click.command()
-@click.option('--file', '-f', prompt='File to parse', help='hexdump to parse')
+@click.argument('file')
 @click.option('--disable-id-annotations', is_flag=True,
               help='disable printing annotations for enumfield ids')
 @click.option('--disable-value-annotations', is_flag=True,

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@ setup(
     license='AGPLv3',
     description='A reference implementation of the tribes ascend server',
     install_requires=[
-        "gevent"
+        "gevent",
+        "click"
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,6 @@ setup(
     license='AGPLv3',
     description='A reference implementation of the tribes ascend server',
     install_requires=[
-        "gevent",
-        "click"
+        "gevent"
     ],
 )


### PR DESCRIPTION
An update to parse.py to give it a more structured command line interface with flags for disabling annotation of ids/values, and for specifying extra CSVs containing annotations