### PR TITLE
Add TCP rules to gameserverlauncher firewall to allow TAMods-Server's connection

### DIFF
--- a/firewall/main.py
+++ b/firewall/main.py
@@ -70,6 +70,19 @@ class Firewall():
         # fail if there are no left-over rules from a previous run.
         sp.call(args, stdout=sp.DEVNULL)
 
+    def reset_tcp_whitelist(self):
+        self.logger.info('Resetting TAserverfirewall TCP whitelist to initial state')
+        args = [
+            'c:\\windows\\system32\\Netsh.exe',
+            'advfirewall',
+            'firewall',
+            'delete',
+            'rule',
+            'name="TAserverfirewall-whitelist-tcp"'
+        ]
+        # Don't check for failure here, because it is expected to
+        # fail if there are no left-over rules from a previous run.
+        sp.call(args, stdout=sp.DEVNULL)
 
     def reset_blacklist(self):
         self.logger.info('Resetting TAserverfirewall blacklist to initial state')
@@ -263,6 +276,13 @@ class Firewall():
                 'port' : 9000,
                 'protocol' : 'tcp',
                 'IPs' : list()
+            },
+            'whitelist-tcp' : {
+                'name': 'TAserverfirewall-whitelist-tcp',
+                'ruletype': 'allow',
+                'port': '%d,%d' % (GAME_PORT1, GAME_PORT2),
+                'protocol': 'tcp',
+                'IPs': list(),
             }
         }
 
@@ -281,6 +301,8 @@ class Firewall():
             if command['action'] == 'reset':
                 if command['list'] == 'whitelist':
                     self.reset_whitelist()
+                elif command['list'] == 'whitelist-tcp':
+                    self.reset_tcp_whitelist()
                 else:
                     self.reset_blacklist()
                 thelist['IPs'] = list()

--- a/game_server_launcher/launcher.py
+++ b/game_server_launcher/launcher.py
@@ -132,6 +132,7 @@ class Launcher:
 
     def run(self):
         reset_firewall('whitelist')
+        reset_firewall('whitelist-tcp')
         self.pending_server_port = game_server_ports[0]
         self.server_handler_queue.put(StartGameServerMessage(self.pending_server_port))
         while True:
@@ -221,6 +222,7 @@ class Launcher:
         if msg.ip:
             self.logger.info('launcher: login server added player %d with ip %s' % (msg.unique_id, msg.ip))
             modify_firewall('whitelist', 'add', msg.unique_id, msg.ip)
+            modify_firewall('whitelist-tcp', 'add', msg.unique_id, msg.ip)
         else:
             self.logger.info('launcher: login server added local player %d' % msg.unique_id)
 
@@ -228,6 +230,7 @@ class Launcher:
         if msg.ip:
             self.logger.info('launcher: login server removed player %d with ip %s' % (msg.unique_id, msg.ip))
             modify_firewall('whitelist', 'remove', msg.unique_id, msg.ip)
+            modify_firewall('whitelist-tcp', 'remove', msg.unique_id, msg.ip)
         else:
             self.logger.info('launcher: login server removed local player %d' % msg.unique_id)
 


### PR DESCRIPTION
TAMods-Server needs the TCP ports equivalent to the gameserver's UDP ports to be open to allow direct connection of players with modded clients.