### PR TITLE
Add missing Heavy energy pack for OOTB

### DIFF
--- a/common/game_items.py
+++ b/common/game_items.py
@@ -483,6 +483,7 @@ _hierarchical_definitions_ootb = {
                 'Brute_Pack_HeavyShield': 7826,
                 'Doombringer_Pack_ForceField': 7411,
                 'Brute_Pack_SurvivalPack': 8255,
+                'Brute_Pack_MinorEnergy': 7830,
             },
             'skins': {
                 'Skin JUG': 8331,


### PR DESCRIPTION
This item was reported as not showing up for OOTB custom servers, looks like its definition was missing here.