### PR TITLE
Add missing argparse import

### DIFF
--- a/download_gotylike.py
+++ b/download_gotylike.py
@@ -18,6 +18,7 @@
 # along with taserver.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+import argparse
 import os
 import shutil
 import tempfile


### PR DESCRIPTION
The download_gotylike script now depends on argparse but doesn't import it.

This adds said import.