### PR TITLE
Provide JSON output of player info on HTTP request for /player

### DIFF
--- a/login_server/loginserver.py
+++ b/login_server/loginserver.py
@@ -24,7 +24,6 @@ import hashlib
 import logging
 import random
 import string
-import glob
 
 from common.connectionhandler import PeerConnectedMessage, PeerDisconnectedMessage
 from common.datatypes import *
@@ -359,12 +358,16 @@ class LoginServer:
                 self.logger.info('Served player stats request via HTTP to Unknown peer')
             
             if "QUERY_STRING" in msg.env:
-                player_data = self.get_player_settings_data(msg.env['QUERY_STRING'])
-                if player_data != False:
+                filtered_player_name = ''.join(filter(str.isalnum, msg.env['QUERY_STRING']))
+                player_data = False
+                if filtered_player_name in self.accounts:
+                    player_data = self.get_player_settings_data(filtered_player_name)
+                
+                if player_data:
                     filtered_player_data = {
                         "player_found": True,
                         "clan_tag": player_data["clan_tag"],
-                        "player_name": msg.env['QUERY_STRING'],
+                        "player_name": filtered_player_name,
                         "rank_xp": player_data["progression"]["rank_xp"]
                     }
                     msg.peer.send_response(json.dumps(filtered_player_data, sort_keys=True, indent=4))
@@ -373,20 +376,18 @@ class LoginServer:
                         'player_found': False
                     }, sort_keys=True, indent=4))
             else:
-                msg.peer.send_response(json.dumps({
-                    'player_found': False
-                }, sort_keys=True, indent=4))
+                msg.peer.send_response(None)
         else:
             msg.peer.send_response(None)
 
     def get_player_settings_data(self, player_name):
         self.logger.info("Retrieved settings data for player: " + player_name)
         try:
-            with open(glob.glob('data/players/' + player_name + '_settings.json')[0], "r") as f:
+            with open('data/players/' + player_name + '_settings.json', "r") as f:
                 file_contents = json.load(f)
             return file_contents
-        except IndexError:
-            return False
+        except FileNotFoundError:
+            return None
 
     def convert_map_id_to_map_name_and_game_type(self, map_id):
         map_names_and_types = {

--- a/login_server/loginserver.py
+++ b/login_server/loginserver.py
@@ -359,7 +359,7 @@ class LoginServer:
             
             if "QUERY_STRING" in msg.env:
                 filtered_player_name = ''.join(filter(str.isalnum, msg.env['QUERY_STRING']))
-                player_data = False
+                player_data = None
                 if filtered_player_name in self.accounts:
                     player_data = self.get_player_settings_data(filtered_player_name)
                 
@@ -381,7 +381,6 @@ class LoginServer:
             msg.peer.send_response(None)
 
     def get_player_settings_data(self, player_name):
-        self.logger.info("Retrieved settings data for player: " + player_name)
         try:
             with open('data/players/' + player_name + '_settings.json', "r") as f:
                 file_contents = json.load(f)


### PR DESCRIPTION
Provides a way to retrieve basic info for a player requested with the URL query string ( /player?NAME ).  

Player info includes:
- Player name,
- Clan tag,
- Rank XP.