### PR TITLE
add option to use external port directly

### DIFF
--- a/game_server_launcher/gameserverhandler.py
+++ b/game_server_launcher/gameserverhandler.py
@@ -77,7 +77,7 @@ class GameServerHandler:
         try:
             self.working_dir = game_server_config['dir']
             self.dll_to_inject = game_server_config['controller_dll']
-            self.dll_config_path = os.path.join(data_root, game_server_config['controller_config'])            
+            self.dll_config_path = os.path.join(data_root, game_server_config['controller_config'])
             self.use_external_port = game_server_config.getboolean('use_external_port', True)
         except KeyError as e:
             raise ConfigurationError("%s is a required configuration item under [gameserver]" % str(e))

--- a/game_server_launcher/gameserverhandler.py
+++ b/game_server_launcher/gameserverhandler.py
@@ -77,13 +77,8 @@ class GameServerHandler:
         try:
             self.working_dir = game_server_config['dir']
             self.dll_to_inject = game_server_config['controller_dll']
-            self.dll_config_path = os.path.join(data_root, game_server_config['controller_config'])
-
-            if game_server_config.get('use_external_port'):
-                self.use_external_port = game_server_config.getboolean('use_external_port')
-            else:
-                self.use_external_port = False
-
+            self.dll_config_path = os.path.join(data_root, game_server_config['controller_config'])            
+            self.use_external_port = game_server_config.getboolean('use_external_port', True)
         except KeyError as e:
             raise ConfigurationError("%s is a required configuration item under [gameserver]" % str(e))
 

--- a/game_server_launcher/gameserverhandler.py
+++ b/game_server_launcher/gameserverhandler.py
@@ -78,7 +78,7 @@ class GameServerHandler:
             self.working_dir = game_server_config['dir']
             self.dll_to_inject = game_server_config['controller_dll']
             self.dll_config_path = os.path.join(data_root, game_server_config['controller_config'])
-            self.use_external_port = game_server_config.getboolean('use_external_port', True)
+            self.use_external_port = game_server_config.getboolean('use_external_port', False)
         except KeyError as e:
             raise ConfigurationError("%s is a required configuration item under [gameserver]" % str(e))
 


### PR DESCRIPTION
This change enables game_server_launcher to be run correctly without the udpproxy, this is mainly for supporting running on linux.
- add use_external_port config so that the game server can listen directly on 7777/7778 when udpproxy is not running.
- when use_external_port is set true, we also pass `-noportoffset` to TribesAscend.exe so that TAMods-server knows not to offset its control port. This allows admin commands to work in this case.

Tested locally with use_external_port not set, and use_external_port=True.

The functionality of `-noportoffset` will require a new release of TAMods-server to work, as this was recently added.