### PR TITLE
Add iptables based firewall

### DIFF
--- a/common/firewall.py
+++ b/common/firewall.py
@@ -28,43 +28,46 @@ from .tcpmessage import TcpMessageWriter
 
 
 class FirewallClient:
-    def __init__(self, ports):
+    def __init__(self, ports, shared_config):
         self.ports = ports
+        # don't try to send commands to udpproxy if its not running
+        self.use_udpproxy = not shared_config.getboolean('use_iptables', False)
 
     def _send_command(self, command):
         server_address = ("127.0.0.1", self.ports['firewall'])
         proxy_addresses = (("127.0.0.1", self.ports['gameserver1firewall']),
                            ("127.0.0.1", self.ports['gameserver2firewall']))
-
+        
         try:
             with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
                 sock.connect(server_address)
                 TcpMessageWriter(sock).send(json.dumps(command).encode('utf8'))
 
-            if command['list'] == 'whitelist':
-                for proxy_address in proxy_addresses:
-                    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
-                        sock.connect(proxy_address)
-                        if command['action'] == 'reset':
-                            message = b'reset'
-                        else:
-                            address = IPv4Address(command['ip'])
-                            action = b'a' if command['action'] == 'add' else b'r'
-                            message = action + struct.pack('<L', command['player_id']) + address.packed
-                        sock.sendall(struct.pack('<L', len(message)))
-                        sock.sendall(message)
-                        sock.shutdown(socket.SHUT_RDWR)
+            if self.use_udpproxy:
+                if command['list'] == 'whitelist':
+                    for proxy_address in proxy_addresses:
+                        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+                            sock.connect(proxy_address)
+                            if command['action'] == 'reset':
+                                message = b'reset'
+                            else:
+                                address = IPv4Address(command['ip'])
+                                action = b'a' if command['action'] == 'add' else b'r'
+                                message = action + struct.pack('<L', command['player_id']) + address.packed
+                            sock.sendall(struct.pack('<L', len(message)))
+                            sock.sendall(message)
+                            sock.shutdown(socket.SHUT_RDWR)
 
         except ConnectionRefusedError:
             logger = logging.getLogger(__name__)
             logger.warning('\n'
-                           '--------------------------------------------------------------\n'
-                           'Warning: Failed to connect to taserver firewall for modifying \n'
-                           'the firewall rules.\n'
-                           'Did you forget to run start_taserver_firewall.py (as admin)?\n'
-                           'If you want to run without the firewall and udpproxy you will need\n'
-                           'to change the gameserver port to 7777 in gameserverlauncher.ini.\n'
-                           '--------------------------------------------------------------')
+                        '--------------------------------------------------------------\n'
+                        'Warning: Failed to connect to taserver firewall for modifying \n'
+                        'the firewall rules.\n'
+                        'Did you forget to run start_taserver_firewall.py (as admin)?\n'
+                        'If you want to run without the firewall and udpproxy you will need\n'
+                        'to change the gameserver port to 7777 in gameserverlauncher.ini.\n'
+                        '--------------------------------------------------------------')
 
     def reset_firewall(self, list_type):
         command = {
@@ -81,4 +84,3 @@ class FirewallClient:
             'ip' : str(ip)
         }
         self._send_command(command)
-

--- a/common/firewall.py
+++ b/common/firewall.py
@@ -31,7 +31,8 @@ class FirewallClient:
     def __init__(self, ports, shared_config):
         self.ports = ports
         # don't try to send commands to udpproxy if its not running
-        self.use_udpproxy = not shared_config.getboolean('use_iptables', False)
+        platform = shared_config.get('platform', 'windows')
+        self.use_udpproxy = (platform == 'windows')
 
     def _send_command(self, command):
         server_address = ("127.0.0.1", self.ports['firewall'])

--- a/data/shared.ini
+++ b/data/shared.ini
@@ -1,2 +1,6 @@
 [shared]
 port_offset = 0
+
+# Linux support: use iptables instead of the windows firewall
+# This also disables udpproxy. You must also set use_external_port=True in gameserverlauncher.ini
+# use_iptables = True

--- a/data/shared.ini
+++ b/data/shared.ini
@@ -1,6 +1,6 @@
 [shared]
 port_offset = 0
 
-# Linux support: use iptables instead of the windows firewall
-# This also disables udpproxy. You must also set use_external_port=True in gameserverlauncher.ini
-# use_iptables = True
+# Linux support:
+# use iptables instead of the windows firewall, disables udpproxy
+# platform = linux

--- a/firewall/iptables_firewall.py
+++ b/firewall/iptables_firewall.py
@@ -1,0 +1,251 @@
+from ipaddress import ip_address
+import ipaddress
+from logging import Logger
+import logging
+import subprocess
+from typing import List, NamedTuple
+
+from gevent.queue import Queue
+
+from common.logging import set_up_logging
+from common.ports import Ports
+
+
+class Rule(NamedTuple):
+  protocol: str = None
+  ports: List[str] = None
+  target: str = None
+  ip_address: str = None
+
+
+class IPTables:
+
+  def __init__(self, logger: Logger):
+    self.logger = logger
+
+  def iptables(self, command: str, chain: str, rule: Rule = Rule(), quiet: bool = False) -> int:
+    args = ['iptables', '-w', command, chain]
+
+    if rule.protocol:
+      args += ['-p', rule.protocol]
+    
+    if rule.ports is not None:
+      if len(rule.ports) == 1:
+        args += ['--dport', rule.ports[0]]
+      elif len(rule.ports) > 1:
+        args += ['-m', 'multiport', '--dport', ','.join(rule.ports)]
+      else:
+        self.logger.error(f'Must specify at least 1 port or None in {rule}')
+        return 1
+
+    if rule.target:
+      args += ['-j', rule.target]
+    
+    if rule.ip_address:
+      args.extend(['-s', rule.ip_address])
+
+    # Suppress error for rule checks, since they are expected to fail
+    if quiet or command == Commands.CHECK_RULE:
+      stderr = subprocess.DEVNULL
+    else:
+      stderr = None
+
+    try:
+      cmd = " ".join(args)
+      result = subprocess.call(args, stderr=stderr)
+      logging.debug(f'{cmd} => {result}')
+      return result
+    except Exception as e:
+      self.logger.error(f'Error while running {args}: {repr(e)}')
+      return 1
+
+
+class Commands():
+  # https://linux.die.net/man/8/iptables
+  APPEND_RULE = '-A'
+  INSERT_RULE = '-I'
+  DELETE_RULE = '-D'
+  NEW_CHAIN = '-N'
+  FLUSH_CHAIN = '-F'
+  DELETE_CHAIN = '-X'
+  CHECK_RULE = '-C'
+
+
+class IPTablesBlacklist(IPTables):
+  """ iptables based firewall for taserver's login server
+
+  We add a new chain called taserver-blacklist. The chain has no default policy so will return to
+  INPUT. It is assumed that the INPUT chain has a default policy of ACCEPT. When a player is banned,
+  we add a rule which matches the IP -> DROP.
+
+  We add a rule to the INPUT chain to forward traffic from client2login to taserver-blacklist chain.
+  """
+  
+  def __init__(self, logger: Logger, ports: Ports):
+    super().__init__(logger)
+    self.ports = [str(ports['client2login'])]
+    self.input_chain = 'INPUT'
+    self.chain = f'taserver-blacklist'
+
+  def add(self, ip_address: str) -> None:
+    self.logger.info(f'{self.chain}: Adding drop rule for {ip_address}')
+    rule = Rule(protocol='tcp', ports=self.ports, target='DROP', ip_address=ip_address)
+    if self.iptables(Commands.CHECK_RULE, self.chain, rule) != 0:
+      self.iptables(Commands.APPEND_RULE, self.chain, rule)
+
+  def remove(self, ip_address: str) -> None:
+    self.logger.info(f'{self.chain}: Removing drop rule for {ip_address}')
+    self.iptables(
+      Commands.DELETE_RULE,
+      self.chain,
+      Rule(protocol='tcp', ports=self.ports, target='DROP', ip_address=ip_address)
+    )
+
+  def remove_all(self) -> None:
+    self.logger.info(f'{self.chain}: Removing all blacklist rules')
+    forward_rule = Rule(protocol='tcp', ports=self.ports, target=self.chain)
+    
+    # Delete forwarding rule from INPUT, if it exists
+    # Suppress error output since the rule may not exist
+    self.iptables(Commands.DELETE_RULE, self.input_chain, forward_rule, quiet=True)
+
+    # Delete the blacklist chain if it exists
+    self.iptables(Commands.FLUSH_CHAIN, self.chain, quiet=True)
+    # Delete the blacklist chain if it exists
+    self.iptables(Commands.DELETE_CHAIN, self.chain, quiet=True)
+
+  def reset(self) -> None:
+    self.logger.info(f'{self.chain}: Resetting all iptables rules')
+    forward_rule = Rule(protocol='tcp', ports=self.ports, target=self.chain)
+    self.remove_all()
+
+    self.logger.info(f'{self.chain}: Setting up blacklist rules')
+    # Create the blacklist chain
+    self.iptables(Commands.NEW_CHAIN, self.chain, quiet=True)
+    
+    if self.iptables(Commands.CHECK_RULE, self.input_chain, forward_rule) != 0:
+      self.iptables(Commands.INSERT_RULE, self.input_chain, forward_rule)
+
+
+class IPTablesWhitelist(IPTables):
+  """ iptables based firewall for taserver's game_server_launcher
+
+  We create a new chain called taserver-whitelist-$OFFSET. When a player is connected, we will add 
+  a rule which matches that player's IP -> ACCEPT. The default policy for this chain is DROP
+
+  We add rules to the INPUT chain to forward traffic for gameserver1, gameserver2, game2launcher to
+  the taserver-whitelist chain.
+  """
+
+  def __init__(self, logger: Logger, ports: Ports):
+    super().__init__(logger)
+    self.ports = list({
+      str(ports['gameserver1']),
+      str(ports['gameserver2']),
+      str(ports['game2launcher']),
+      str(ports['launcherping'])
+    })
+
+    # The chain from which we forward traffic to the offset-specific chain
+    self.input_chain = 'INPUT'
+    # name of the chain for this instance of game_server_launcher
+    self.chain = f'taserver-whitelist-{ports.portOffset}'
+
+  def add(self, ip_address: str) -> None:
+    self.logger.info(f'{self.chain}: Adding accept rule for {ip_address}')
+    tcp_rule = Rule(protocol='tcp', ports=self.ports, target='ACCEPT', ip_address=ip_address)
+    udp_rule = Rule(protocol='udp', ports=self.ports, target='ACCEPT', ip_address=ip_address)
+    
+    # Prepend rules to accept TCP & UDP traffic from this IP
+    # Check if rules already exist to avoid duplicates
+    if self.iptables(Commands.CHECK_RULE, self.chain, tcp_rule) != 0:
+      self.iptables(Commands.INSERT_RULE, self.chain, tcp_rule)
+
+    if self.iptables(Commands.CHECK_RULE, self.chain, udp_rule) != 0:
+      self.iptables(Commands.INSERT_RULE, self.chain, udp_rule)
+
+  def remove(self, ip_address: str) -> None:    
+    self.logger.info(f'{self.chain}: Removing accept rule for {ip_address}')
+    tcp_rule = Rule(protocol='tcp', ports=self.ports, target='ACCEPT', ip_address=ip_address)
+    udp_rule = Rule(protocol='udp', ports=self.ports, target='ACCEPT', ip_address=ip_address)
+
+    # Delete rules to accept traffic from this IP
+    self.iptables(Commands.DELETE_RULE, self.chain, tcp_rule)
+    self.iptables(Commands.DELETE_RULE, self.chain, udp_rule)
+
+  def remove_all(self) -> None:
+    self.logger.info(f'{self.chain}: Removing all whitelist rules')
+    forward_tcp_rule = Rule(protocol='tcp', ports=self.ports, target=self.chain)
+    forward_udp_rule = Rule(protocol='udp', ports=self.ports, target=self.chain)
+
+    # Delete forwarding rules from INPUT, if it exists
+    # Suppress error output since these rules may not exist
+    self.iptables(Commands.DELETE_RULE, self.input_chain, forward_tcp_rule, quiet=True)
+    self.iptables(Commands.DELETE_RULE, self.input_chain, forward_udp_rule, quiet=True)
+
+    # Delete the whitelist chain, if it exists
+    self.iptables(Commands.FLUSH_CHAIN, self.chain, quiet=True)
+    self.iptables(Commands.DELETE_CHAIN, self.chain, quiet=True)
+
+  def reset(self) -> None:
+    self.logger.info(f'{self.chain}: Resetting all whitelist rules')
+    self.remove_all()
+
+    forward_tcp_rule = Rule(protocol='tcp', ports=self.ports, target=self.chain)
+    forward_udp_rule = Rule(protocol='udp', ports=self.ports, target=self.chain)
+
+    self.logger.info(f'{self.chain}: Setting up whitelist rules')
+    # Create new taserver chain with default rule to drop all traffic
+    self.iptables(Commands.NEW_CHAIN, self.chain)
+    self.iptables(Commands.APPEND_RULE, self.chain, Rule(target='DROP'))
+    # allow traffic from localhost so that game server and launcher can communicate
+    self.iptables(Commands.INSERT_RULE, self.chain, Rule(ip_address='127.0.0.1', target='ACCEPT'))
+
+    # Forward this game server's traffic from INPUT chain to taserver chain
+    if self.iptables(Commands.CHECK_RULE, self.input_chain, forward_tcp_rule) != 0:
+      self.iptables(Commands.INSERT_RULE, self.input_chain, forward_tcp_rule)
+    
+    if self.iptables(Commands.CHECK_RULE, self.input_chain, forward_udp_rule) != 0:
+      self.iptables(Commands.INSERT_RULE, self.input_chain, forward_udp_rule)
+
+
+class IPTablesFirewall():
+
+  def __init__(self, ports: Ports, data_root: str) -> None:
+    set_up_logging(data_root, 'taserver_firewall.log')
+    self.logger = logging.getLogger('firewall')
+    self.blacklist = IPTablesBlacklist(self.logger, ports)
+    self.whitelist = IPTablesWhitelist(self.logger, ports)
+
+  
+  def remove_all_rules(self) -> None:
+    self.logger.info(f'Removing all firewall rules')
+    self.blacklist.remove_all()
+    self.whitelist.remove_all()
+  
+  def run(self, server_queue: Queue) -> None:
+    lists = {
+      'whitelist': self.whitelist,
+      'blacklist': self.blacklist
+    }
+
+    self.blacklist.reset()
+    self.whitelist.reset()
+
+    while True:
+      try:
+        command = server_queue.get()
+        thelist = lists[command['list']]
+
+        if command['action'] == 'reset':
+            thelist.reset()
+        elif command['action'] == 'add':
+            ip = str(ip_address(command['ip']))
+            thelist.add(ip)
+        elif command['action'] == 'remove':
+            ip = str(ip_address(command['ip']))
+            thelist.remove(ip)
+        else:
+            self.logger.error('Invalid action received: %s' % command['action'])
+      except Exception as e:
+        self.logger.error(f'Exception while handling command: {repr(e)}')

--- a/firewall/main.py
+++ b/firewall/main.py
@@ -40,6 +40,8 @@ def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('--data-root', action='store', default='data',
                         help='Location of the data dir containing all config files and logs.')
+    parser.add_argument('--port-offset', action='store', default=None,
+                        help='Override port offset in the config')
     args = parser.parse_args()
     data_root = args.data_root
 
@@ -47,7 +49,11 @@ def main():
     with open(get_shared_ini_path(data_root)) as f:
         config.read_file(f)
 
-    ports = Ports(int(config['shared']['port_offset']))
+    if args.port_offset is not None:
+        print(f"Using port offset flag: {int(args.port_offset)}")
+        ports = Ports(int(args.port_offset))
+    else:
+        ports = Ports(int(config['shared']['port_offset']))
     use_iptables = config['shared'].getboolean('use_iptables', False)
     udpproxy_enabled = not use_iptables
 

--- a/firewall/main.py
+++ b/firewall/main.py
@@ -24,165 +24,15 @@ import gevent.queue
 from gevent.server import StreamServer
 import gevent.subprocess as sp
 import json
-import logging
-import os
 import sys
 
 from common.geventwrapper import gevent_spawn
-from common.logging import set_up_logging
 from common.ports import Ports
 from common.tcpmessage import TcpMessageReader
 from common.utils import get_shared_ini_path
 
-from .utils import FirewallUtils
-
-
-class Rulelist:
-    def __init__(self, ports):
-        self.IPs = set()
-        self.ports = ports
-
-    def has_ip(self, ip):
-        return ip in self.IPs
-
-    def add(self, ip):
-        if ip not in self.IPs:
-            self.IPs.add(ip)
-            return True
-        else:
-            return False
-
-    def remove(self, ip):
-        if ip in self.IPs:
-            self.IPs.remove(ip)
-            return True
-        else:
-            return False
-
-
-class Blacklist(Rulelist):
-
-    def __init__(self, utils, logger, ports):
-        super().__init__(ports)
-        self.utils = utils
-        self.logger = logger
-        self.name = 'TAserverfirewall-blacklist'
-        if self.ports.portOffset:
-            self.name += f'_offset{self.ports.portOffset}'
-
-    def remove_all(self):
-        self.utils.remove_rules_by_name(self.name)
-
-    def reset(self):
-        self.logger.info('Resetting blacklist to initial state')
-        self.remove_all()
-
-        args = [
-            'c:\\windows\\system32\\Netsh.exe',
-            'advfirewall',
-            'firewall',
-            'add',
-            'rule',
-            'name="%s"' % self.name,
-            'protocol=tcp',
-            'dir=in',
-            'enable=yes',
-            'profile=any',
-            'localport=%d' % self.ports['client2login'],
-            'action=allow'
-        ]
-        try:
-            sp.check_output(args, text = True)
-        except sp.CalledProcessError as e:
-            self.logger.error('Failed to add initial rule to firewall during reset of blacklist:\n'
-                              '%s' % e.output)
-
-    def add(self, ip):
-        if super().add(ip):
-            self.utils.add_rule(self.name, ip, self.ports['client2login'], 'tcp', 'block')
-
-    def remove(self, ip):
-        if super().remove(ip):
-            self.utils.remove_rule(self.name, ip, self.ports['client2login'], 'tcp', 'block')
-
-
-class Whitelist(Rulelist):
-
-    def __init__(self, utils, logger, ports):
-        super().__init__(ports)
-        self.utils = utils
-        self.logger = logger
-        self.name = 'TAserverfirewall-whitelist'
-        if self.ports.portOffset:
-            self.name += f'_offset{self.ports.portOffset}'
-
-    def remove_all(self):
-        self.utils.remove_rules_by_name(self.name)
-
-    def reset(self):
-        self.logger.info('Resetting whitelist to initial state')
-        self.remove_all()
-
-    def add(self, ip):
-        if super().add(ip):
-            for protocol in ('udp', 'tcp'):
-                self.utils.add_rule(self.name, ip, '%d,%d' % (self.ports['gameserver1'], self.ports['gameserver2']), protocol, 'allow')
-
-    def remove(self, ip):
-        if super().remove(ip):
-            for protocol in ('udp', 'tcp'):
-                self.utils.remove_rule(self.name, ip, '%d,%d' % (self.ports['gameserver1'], self.ports['gameserver2']), protocol, 'allow')
-
-
-class Firewall:
-    def __init__(self, ports, data_root):
-        set_up_logging(data_root, 'taserver_firewall.log')
-        self.logger = logging.getLogger('firewall')
-        self.ports = ports
-        self.utils = FirewallUtils(self.logger)
-        self.blacklist = Blacklist(self.utils, self.logger, ports)
-        self.whitelist = Whitelist(self.utils, self.logger, ports)
-        self.name = 'TAserverfirewall-general'
-        if self.ports.portOffset:
-            self.name += f'_offset{self.ports.portOffset}'
-
-    def remove_all_rules(self):
-        self.logger.info('Removing any previous TAserverfirewall rules')
-        self.utils.remove_rules_by_name(self.name)
-        self.blacklist.remove_all()
-        self.whitelist.remove_all()
-
-    def run(self, server_queue):
-        lists = {
-            'whitelist': self.whitelist,
-            'blacklist': self.blacklist
-        }
-
-        # First disable the rules that are created by Windows itself when you run tribesascend.exe
-        tribes_ascend_programs = set(rule['Program'] for rule in self.utils.find_tribes_ascend_rules())
-        for program in tribes_ascend_programs:
-            self.utils.disable_rules_for_program_name(program)
-
-        self.utils.add_rule(self.name, 'any', self.ports['launcher2login'], 'tcp', 'allow') # for game servers
-        self.utils.add_rule(self.name, 'any', self.ports['restapi'], 'tcp', 'allow') # for REST
-        self.utils.add_rule(self.name, 'any', self.ports['launcherping'], 'udp', 'allow') # for in-game pings
-        self.whitelist.reset()
-        self.blacklist.reset()
-
-        while True:
-            command = server_queue.get()
-            thelist = lists[command['list']]
-
-            if command['action'] == 'reset':
-                thelist.reset()
-            elif command['action'] == 'add':
-                ip = command['ip']
-                thelist.add(ip)
-            elif command['action'] == 'remove':
-                ip = command['ip']
-                thelist.remove(ip)
-            else:
-                self.logger.error('Invalid action received: %s' % command['action'])
+from .windows_firewall import Firewall
+from .iptables_firewall import IPTablesFirewall
 
 
 def main():
@@ -198,20 +48,27 @@ def main():
         config.read_file(f)
 
     ports = Ports(int(config['shared']['port_offset']))
+    use_iptables = config['shared'].getboolean('use_iptables', False)
+    udpproxy_enabled = not use_iptables
 
-    try:
-        udp_proxy_proc1 = sp.Popen('udpproxy.exe %d' % ports['gameserver1'])
-        udp_proxy_proc2 = sp.Popen('udpproxy.exe %d' % ports['gameserver2'])
+    if udpproxy_enabled:
+        try:
+            udp_proxy_proc1 = sp.Popen('udpproxy.exe %d' % ports['gameserver1'])
+            udp_proxy_proc2 = sp.Popen('udpproxy.exe %d' % ports['gameserver2'])
 
-    except OSError as e:
-        print('Failed to run udpproxy.exe. Run download_udpproxy.py to download it\n'
-              'or build it yourself using the Visual Studio solution in the udpproxy\n'
-              'subdirectory and place it in the taserver directory.\n',
-              file=sys.stderr)
-        return
+        except OSError as e:
+            print('Failed to run udpproxy.exe. Run download_udpproxy.py to download it\n'
+                'or build it yourself using the Visual Studio solution in the udpproxy\n'
+                'subdirectory and place it in the taserver directory.\n',
+                file=sys.stderr)
+            return
 
     server_queue = gevent.queue.Queue()
-    firewall = Firewall(ports, data_root)
+    
+    if use_iptables:
+        firewall = IPTablesFirewall(ports, data_root)
+    else:
+        firewall = Firewall(ports, data_root)
     gevent_spawn('firewall.run', firewall.run, server_queue)
 
     def handle_client(socket, address):
@@ -225,5 +82,6 @@ def main():
     except KeyboardInterrupt:
         firewall.remove_all_rules()
 
-    udp_proxy_proc1.terminate()
-    udp_proxy_proc2.terminate()
+    if udpproxy_enabled:
+        udp_proxy_proc1.terminate()
+        udp_proxy_proc2.terminate()

--- a/firewall/main.py
+++ b/firewall/main.py
@@ -54,8 +54,9 @@ def main():
         ports = Ports(int(args.port_offset))
     else:
         ports = Ports(int(config['shared']['port_offset']))
-    use_iptables = config['shared'].getboolean('use_iptables', False)
-    udpproxy_enabled = not use_iptables
+    platform = config['shared'].get('platform', 'windows')
+    use_iptables = (platform == 'linux')
+    udpproxy_enabled = (platform == 'windows')
 
     if udpproxy_enabled:
         try:

--- a/firewall/windows_firewall.py
+++ b/firewall/windows_firewall.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2018  Maurice van der Pot <griffon26@kfk4ever.com>
+#
+# This file is part of taserver
+#
+# taserver is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# taserver is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with taserver.  If not, see <http://www.gnu.org/licenses/>.
+#
+import gevent.subprocess as sp
+import logging
+
+from common.logging import set_up_logging
+
+from .utils import FirewallUtils
+
+
+class Rulelist:
+    def __init__(self, ports):
+        self.IPs = set()
+        self.ports = ports
+
+    def has_ip(self, ip):
+        return ip in self.IPs
+
+    def add(self, ip):
+        if ip not in self.IPs:
+            self.IPs.add(ip)
+            return True
+        else:
+            return False
+
+    def remove(self, ip):
+        if ip in self.IPs:
+            self.IPs.remove(ip)
+            return True
+        else:
+            return False
+
+
+class Blacklist(Rulelist):
+
+    def __init__(self, utils, logger, ports):
+        super().__init__(ports)
+        self.utils = utils
+        self.logger = logger
+        self.name = 'TAserverfirewall-blacklist'
+        if self.ports.portOffset:
+            self.name += f'_offset{self.ports.portOffset}'
+
+    def remove_all(self):
+        self.utils.remove_rules_by_name(self.name)
+
+    def reset(self):
+        self.logger.info('Resetting blacklist to initial state')
+        self.remove_all()
+
+        args = [
+            'c:\\windows\\system32\\Netsh.exe',
+            'advfirewall',
+            'firewall',
+            'add',
+            'rule',
+            'name="%s"' % self.name,
+            'protocol=tcp',
+            'dir=in',
+            'enable=yes',
+            'profile=any',
+            'localport=%d' % self.ports['client2login'],
+            'action=allow'
+        ]
+        try:
+            sp.check_output(args, text = True)
+        except sp.CalledProcessError as e:
+            self.logger.error('Failed to add initial rule to firewall during reset of blacklist:\n'
+                              '%s' % e.output)
+
+    def add(self, ip):
+        if super().add(ip):
+            self.utils.add_rule(self.name, ip, self.ports['client2login'], 'tcp', 'block')
+
+    def remove(self, ip):
+        if super().remove(ip):
+            self.utils.remove_rule(self.name, ip, self.ports['client2login'], 'tcp', 'block')
+
+
+class Whitelist(Rulelist):
+
+    def __init__(self, utils, logger, ports):
+        super().__init__(ports)
+        self.utils = utils
+        self.logger = logger
+        self.name = 'TAserverfirewall-whitelist'
+        if self.ports.portOffset:
+            self.name += f'_offset{self.ports.portOffset}'
+
+    def remove_all(self):
+        self.utils.remove_rules_by_name(self.name)
+
+    def reset(self):
+        self.logger.info('Resetting whitelist to initial state')
+        self.remove_all()
+
+    def add(self, ip):
+        if super().add(ip):
+            for protocol in ('udp', 'tcp'):
+                self.utils.add_rule(self.name, ip, '%d,%d' % (self.ports['gameserver1'], self.ports['gameserver2']), protocol, 'allow')
+
+    def remove(self, ip):
+        if super().remove(ip):
+            for protocol in ('udp', 'tcp'):
+                self.utils.remove_rule(self.name, ip, '%d,%d' % (self.ports['gameserver1'], self.ports['gameserver2']), protocol, 'allow')
+
+
+class Firewall:
+    def __init__(self, ports, data_root):
+        set_up_logging(data_root, 'taserver_firewall.log')
+        self.logger = logging.getLogger('firewall')
+        self.ports = ports
+        self.utils = FirewallUtils(self.logger)
+        self.blacklist = Blacklist(self.utils, self.logger, ports)
+        self.whitelist = Whitelist(self.utils, self.logger, ports)
+        self.name = 'TAserverfirewall-general'
+        if self.ports.portOffset:
+            self.name += f'_offset{self.ports.portOffset}'
+
+    def remove_all_rules(self):
+        self.logger.info('Removing any previous TAserverfirewall rules')
+        self.utils.remove_rules_by_name(self.name)
+        self.blacklist.remove_all()
+        self.whitelist.remove_all()
+
+    def run(self, server_queue):
+        lists = {
+            'whitelist': self.whitelist,
+            'blacklist': self.blacklist
+        }
+
+        # First disable the rules that are created by Windows itself when you run tribesascend.exe
+        tribes_ascend_programs = set(rule['Program'] for rule in self.utils.find_tribes_ascend_rules())
+        for program in tribes_ascend_programs:
+            self.utils.disable_rules_for_program_name(program)
+
+        self.utils.add_rule(self.name, 'any', self.ports['launcher2login'], 'tcp', 'allow') # for game servers
+        self.utils.add_rule(self.name, 'any', self.ports['restapi'], 'tcp', 'allow') # for REST
+        self.utils.add_rule(self.name, 'any', self.ports['launcherping'], 'udp', 'allow') # for in-game pings
+        self.whitelist.reset()
+        self.blacklist.reset()
+
+        while True:
+            command = server_queue.get()
+            thelist = lists[command['list']]
+
+            if command['action'] == 'reset':
+                thelist.reset()
+            elif command['action'] == 'add':
+                ip = command['ip']
+                thelist.add(ip)
+            elif command['action'] == 'remove':
+                ip = command['ip']
+                thelist.remove(ip)
+            else:
+                self.logger.error('Invalid action received: %s' % command['action'])

--- a/game_server_launcher/gameserverhandler.py
+++ b/game_server_launcher/gameserverhandler.py
@@ -78,7 +78,7 @@ class GameServerHandler:
             self.working_dir = game_server_config['dir']
             self.dll_to_inject = game_server_config['controller_dll']
             self.dll_config_path = os.path.join(data_root, game_server_config['controller_config'])
-            self.use_external_port = game_server_config.getboolean('use_external_port', False)
+            self.platform = game_server_config.get('platform', 'windows')
         except KeyError as e:
             raise ConfigurationError("%s is a required configuration item under [gameserver]" % str(e))
 
@@ -131,7 +131,7 @@ class GameServerHandler:
     def start_server_process(self, server):
         external_port = self.ports[server]
 
-        if self.use_external_port:
+        if self.platform == 'linux':
             # udpproxy is disabled, so listen directly on the port
             internal_port = external_port
         else:
@@ -156,7 +156,7 @@ class GameServerHandler:
             args.extend(['-tamodsconfig', self.dll_config_path])
         # By default, TAMods-server will listen on port-100/tcp. If udpproxy is not running,
         # -noportoffset will allow TAMods server to still listen on the same port as the game server's udp.
-        if self.use_external_port:
+        if self.platform == 'linux':
             args.extend(['-noportoffset'])
         process = sp.Popen(args, cwd=self.working_dir)
         self.servers[server] = process

--- a/game_server_launcher/launcher.py
+++ b/game_server_launcher/launcher.py
@@ -82,14 +82,14 @@ class IncompatibleVersionError(FatalError):
 
 @statetracer('address_pair', 'players')
 class Launcher:
-    def __init__(self, game_server_config, ports, incoming_queue, server_handler_queue, data_root):
+    def __init__(self, game_server_config, shared_config, ports, incoming_queue, server_handler_queue, data_root):
         gevent.getcurrent().name = 'launcher'
 
         self.pending_callbacks = PendingCallbacks(incoming_queue)
 
         self.logger = logging.getLogger(__name__)
         self.ports = ports
-        self.firewall = FirewallClient(ports)
+        self.firewall = FirewallClient(ports, shared_config)
         self.game_server_config = game_server_config
         self.incoming_queue = incoming_queue
         self.server_handler_queue = server_handler_queue
@@ -487,7 +487,7 @@ class Launcher:
                 self.last_server_ready_message = msg
 
 
-def handle_launcher(game_server_config, ports, incoming_queue, server_handler_queue, data_root):
-    launcher = Launcher(game_server_config, ports, incoming_queue, server_handler_queue, data_root)
+def handle_launcher(game_server_config, shared_config, ports, incoming_queue, server_handler_queue, data_root):
+    launcher = Launcher(game_server_config, shared_config, ports, incoming_queue, server_handler_queue, data_root)
     # launcher.trace_as('launcher')
     launcher.run()

--- a/game_server_launcher/main.py
+++ b/game_server_launcher/main.py
@@ -89,6 +89,7 @@ def main():
                 gevent_spawn("game server launcher's handle_launcher",
                              handle_launcher,
                              config['gameserver'],
+                             config['shared'],
                              ports,
                              incoming_queue,
                              server_handler_queue,

--- a/login_server/gameserver.py
+++ b/login_server/gameserver.py
@@ -53,11 +53,11 @@ LEVEL_15_XP = 109815
              'players', 'player_being_kicked', 'match_end_time_rel_or_abs', 'match_time_counting',
              'be_score', 'ds_score', 'map_id', )
 class GameServer(Peer):
-    def __init__(self, detected_ip: IPv4Address, ports):
+    def __init__(self, detected_ip: IPv4Address, ports, shared_config):
         super().__init__()
 
         self.logger = logging.getLogger(__name__)
-        self.firewall = FirewallClient(ports)
+        self.firewall = FirewallClient(ports, shared_config)
         self.login_server = None
         self.server_id = None
         self.match_id = None

--- a/login_server/gameserverlauncherhandler.py
+++ b/login_server/gameserverlauncherhandler.py
@@ -37,20 +37,21 @@ class GameServerLauncherWriter(TcpMessageConnectionWriter):
 
 
 class GameServerLauncherHandler(IncomingConnectionHandler):
-    def __init__(self, incoming_queue, ports):
+    def __init__(self, incoming_queue, ports, shared_config):
         super().__init__('gameserverlauncher',
                          '0.0.0.0',
                          ports['launcher2login'],
                          incoming_queue)
         self.ports = ports
+        self.shared_config = shared_config
 
     def create_connection_instances(self, sock, address):
         reader = GameServerLauncherReader(sock)
         writer = GameServerLauncherWriter(sock)
-        peer = GameServer(IPv4Address(address[0]), self.ports)
+        peer = GameServer(IPv4Address(address[0]), self.ports, self.shared_config)
         return reader, writer, peer
 
 
-def handle_game_server_launcher(incoming_queue, ports):
-    game_controller_handler = GameServerLauncherHandler(incoming_queue, ports)
+def handle_game_server_launcher(incoming_queue, ports, shared_config):
+    game_controller_handler = GameServerLauncherHandler(incoming_queue, ports, shared_config)
     game_controller_handler.run()

--- a/login_server/loginserver.py
+++ b/login_server/loginserver.py
@@ -48,7 +48,7 @@ UNUSED_AUTHCODE_CHECK_TIME = 3600
 
 @statetracer('address_pair', 'game_servers', 'players')
 class LoginServer:
-    def __init__(self, server_queue, client_queues, server_stats_queue, ports, accounts):
+    def __init__(self, server_queue, client_queues, server_stats_queue, ports, accounts, shared_config):
         self.logger = logging.getLogger(__name__)
         self.server_queue = server_queue
         self.client_queues = client_queues
@@ -58,7 +58,7 @@ class LoginServer:
 
         self.players = TracingDict()
         self.social_network = SocialNetwork()
-        self.firewall = FirewallClient(ports)
+        self.firewall = FirewallClient(ports, shared_config)
         self.accounts = accounts
         self.message_handlers = {
             Auth2LoginAuthCodeRequestMessage: self.handle_authcode_request_message,

--- a/login_server/main.py
+++ b/login_server/main.py
@@ -51,8 +51,8 @@ def handle_dump(dumpqueue):
         traffic_dumper.run()
 
 
-def handle_server(server_queue, client_queues, server_stats_queue, ports, accounts):
-    server = LoginServer(server_queue, client_queues, server_stats_queue, ports, accounts)
+def handle_server(server_queue, client_queues, server_stats_queue, ports, accounts, shared_config):
+    server = LoginServer(server_queue, client_queues, server_stats_queue, ports, accounts, shared_config)
     # server.trace_as('loginserver')
     server.run()
 
@@ -104,7 +104,8 @@ def main():
                      client_queues,
                      server_stats_queue,
                      ports,
-                     accounts),
+                     accounts,
+                     config['shared']),
         gevent_spawn("login server's handle_authcodes",
                      handle_authcodes,
                      server_queue),
@@ -122,7 +123,8 @@ def main():
         gevent_spawn("login server's handle_game_server_launcher",
                      handle_game_server_launcher,
                      server_queue,
-                     ports)
+                     ports,
+                     config['shared'])
     ]
     # Give the greenlets enough time to start up, otherwise killall can block
     gevent.sleep(1)


### PR DESCRIPTION
Adds an iptables based firewall implementation for linux compatibility. 

The following changes are included:

- Moved all windows firewall classes (`Firewall`, `Whitelist`, `Blacklist`) from firewall/main.py to fiirewall/windows_firewall.py
- added `IPTablesFirewall` class in iptables_firewall.py. This class exposes the exact same interface as `Firewall`, except using iptables internally to manage rules.
- added a optional config `use_iptables` to shared.ini.
  - when false (or empty), nothing changes, the windows firewall is run as before
  -  When this is set to true:
     - firewall/main.py will swap in the implementation in iptables_firewall.py instead of windows_firewall.py. udpproxy will not be started.
     - the common/firewall client will not attempt to send messages to udpproxy, since it won't be running when iptables implementation is used.

Testing:
- Tested login server & firewall running on ubuntu with `use_iptables = True` in shared.ini. Confirmed that players can join games and get votekicked from the server successfully.
- Tested login server & firewall on windows to make sure everything was still working there