### PR TITLE
Launch using wine on linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ __pycache__/
 .mypy_cache/
 /TAMods-Server.dll
 /udpproxy.exe
+/InjectorStandalone.exe
 /data.*.bkp/

--- a/data/gameserverlauncher.ini
+++ b/data/gameserverlauncher.ini
@@ -10,3 +10,7 @@ controller_config = gamesettings\ootb\serverconfig.lua
 # To run a GOTY server you should run the download_gotylike.py script
 # and replace the controller_config setting above with this one:
 #   controller_config = gamesettings\gotylike\serverconfig.lua
+
+# To launch with wine, add these lines to [gameserver]
+# Run download_injector.py to get the latest InjectorStandalone.exe
+# injector_exe = InjectorStandalone.exe

--- a/download_injector.py
+++ b/download_injector.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2018  Maurice van der Pot <griffon26@kfk4ever.com>
+#
+# This file is part of taserver
+#
+# taserver is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# taserver is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with taserver.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+import os
+from urllib.error import HTTPError
+import urllib.request as urlreq
+
+
+target_filename = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'InjectorStandalone.exe')
+download_url = 'https://github.com/mcoot/TribesLauncherSharp/releases/download/inj_0.1/InjectorStandalone.exe'
+
+
+class UserError(Exception):
+    pass
+
+def main():
+    print('Downloading %s\nto %s' % (download_url, target_filename))
+    try:
+        result = urlreq.urlopen(download_url)
+        with open(target_filename, 'wb') as outfile:
+            outfile.write(result.read())
+    except HTTPError as e:
+        raise UserError('download failed: %s' % e)
+
+    print('Done.')
+
+
+if __name__ == '__main__':
+    try:
+        main()
+    except UserError as e:
+        print('\nError: %s' % e)
+        exit(-1)

--- a/game_server_launcher/gameserverhandler.py
+++ b/game_server_launcher/gameserverhandler.py
@@ -18,14 +18,11 @@
 # along with taserver.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-import ctypes.wintypes
 import gevent
-import gevent.subprocess as sp
 import logging
 import os
 import time
 
-from .inject import inject
 from common.errors import FatalError
 from common.geventwrapper import gevent_spawn
 
@@ -62,7 +59,7 @@ class GameServerTerminatedMessage:
 
 class GameServerHandler:
 
-    def __init__(self, game_server_config, ports, server_handler_queue, launcher_queue, data_root):
+    def __init__(self, game_server_config, shared_config, ports, server_handler_queue, launcher_queue, data_root):
         gevent.getcurrent().name = 'gameserver'
 
         self.servers = {}
@@ -78,7 +75,9 @@ class GameServerHandler:
             self.working_dir = game_server_config['dir']
             self.dll_to_inject = game_server_config['controller_dll']
             self.dll_config_path = os.path.join(data_root, game_server_config['controller_config'])
-            self.platform = game_server_config.get('platform', 'windows')
+            self.platform = shared_config.get('platform', 'windows')
+            if self.platform == 'linux':
+                self.injector_exe = game_server_config['injector_exe']
         except KeyError as e:
             raise ConfigurationError("%s is a required configuration item under [gameserver]" % str(e))
 
@@ -148,20 +147,32 @@ class GameServerHandler:
             pass
 
         self.logger.info(f'{server}: starting a new TribesAscend server on port {external_port}...')
-        args = [self.exe_path, 'server',
-                '-abslog=%s' % os.path.abspath(log_filename),
-                '-port=%d' % internal_port,
-                '-controlport', str(self.ports['game2launcher'])]
-        if self.dll_config_path is not None:
-            args.extend(['-tamodsconfig', self.dll_config_path])
-        # By default, TAMods-server will listen on port-100/tcp. If udpproxy is not running,
-        # -noportoffset will allow TAMods server to still listen on the same port as the game server's udp.
-        if self.platform == 'linux':
-            args.extend(['-noportoffset'])
-        process = sp.Popen(args, cwd=self.working_dir)
-        self.servers[server] = process
-        self.logger.info(f'{server}: started process with pid {process.pid}')
+        
+        if self.platform == 'windows':
+            from .gameserverprocess import GameServerProcess
+            process = GameServerProcess(
+                working_dir=self.working_dir, 
+                abslog=os.path.abspath(log_filename),
+                port=internal_port,
+                control_port=self.ports['game2launcher'],
+                dll_to_inject=self.dll_to_inject,
+                dll_config_path=self.dll_config_path
+            )
+        elif self.platform == 'linux':
+            from .winegameserverprocess import WineGameServerProcess
+            process = WineGameServerProcess(
+                working_dir=self.working_dir,
+                abslog=os.path.abspath(log_filename),
+                port=internal_port,
+                control_port=self.ports['game2launcher'],
+                injector_path=self.injector_exe,
+                dll_to_inject=self.dll_to_inject,
+                dll_config_path=self.dll_config_path
+            )
 
+        self.servers[server] = process
+        process.start()
+        self.logger.info(f'{server}: started process with pid {process.pid}')
         # Check if it doesn't exit right away
         time.sleep(2)
         ret_code = process.poll()
@@ -174,7 +185,7 @@ class GameServerHandler:
             self.logger.warning(f'{server}: timeout waiting for log entry, continuing with injection...')
 
         self.logger.info(f'{server}: injecting game controller DLL into game server...')
-        inject(process.pid, self.dll_to_inject)
+        process.inject()
         self.logger.info(f'{server}: injection done.')
 
         self.watcher_task = gevent_spawn('gameserver process watcher for server %s' % server, self.server_process_watcher, process, server)
@@ -186,18 +197,18 @@ class GameServerHandler:
             process.terminate()
 
     def freeze_server_process(self, server):
-        pid = self.servers[server].pid
-        if not ctypes.windll.kernel32.DebugActiveProcess(pid):
-            self.logger.error(f'{server}: failed to freeze game server process {pid}')
+        process = self.servers[server]
+        if not process.freeze():
+            self.logger.error(f'{server}: failed to freeze game server process {process.pid}')
         else:
-            self.logger.info(f'{server}: game server process {pid} frozen')
+            self.logger.info(f'{server}: game server process {process.pid} frozen')
 
     def unfreeze_server_process(self, server):
-        pid = self.servers[server].pid
-        if not ctypes.windll.kernel32.DebugActiveProcessStop(pid):
-            self.logger.error(f'{server}: failed to unfreeze game server process {pid}')
+        process = self.servers[server]
+        if not process.unfreeze():
+            self.logger.error(f'{server}: failed to unfreeze game server process {process.pid}')
         else:
-            self.logger.info(f'{server}: game server process {pid} unfrozen')
+            self.logger.info(f'{server}: game server process {process.pid} unfrozen')
 
     def terminate_all_servers(self):
         existing_servers = self.servers
@@ -223,8 +234,9 @@ class GameServerHandler:
             self.terminate_all_servers()
 
 
-def handle_game_server(game_server_config, ports, server_handler_queue, incoming_queue, data_root):
+def handle_game_server(game_server_config, shared_config, ports, server_handler_queue, incoming_queue, data_root):
     game_server_handler = GameServerHandler(game_server_config,
+                                            shared_config,
                                             ports,
                                             server_handler_queue,
                                             incoming_queue,

--- a/game_server_launcher/gameserverprocess.py
+++ b/game_server_launcher/gameserverprocess.py
@@ -1,0 +1,59 @@
+import ctypes
+import gevent.subprocess as sp
+import os
+
+from .inject import inject
+
+class GameServerProcess():
+  """
+  Standard game server process running in Windows
+  """
+
+  def __init__(
+    self, 
+    working_dir,
+    abslog,
+    port,
+    control_port,
+    dll_to_inject,
+    dll_config_path=None,
+    ):
+
+    self.working_dir = working_dir
+    self.abslog = abslog
+    self.port = port
+    self.control_port = control_port
+    self.dll_to_inject = dll_to_inject
+    self.dll_config_path = dll_config_path
+
+  def start(self):
+    exe_path = os.path.join(self.working_dir, 'TribesAscend.exe')
+    args = [exe_path, 'server',
+      f'-abslog={self.abslog}',
+      f'-port={self.port}',
+      f'-controlport', str(self.control_port)
+    ]
+
+    if self.dll_config_path is not None:
+      args.extend(['-tamodsconfig', self.dll_config_path])
+
+    self.process = sp.Popen(args, cwd=self.working_dir)
+    self.pid = self.process.pid
+
+  def poll(self):
+    return self.process.poll()
+
+  def wait(self):
+    return self.process.wait()
+
+  def terminate(self):
+    self.process.terminate()
+
+  def freeze(self):
+    return ctypes.windll.kernel32.DebugActiveProcess(self.pid)
+
+  def unfreeze(self):
+    return ctypes.windll.kernel32.DebugActiveProcessStop(self.pid)
+  
+  def inject(self):
+    inject(self.process.pid, self.dll_to_inject)

--- a/game_server_launcher/gameserverprocess.py
+++ b/game_server_launcher/gameserverprocess.py
@@ -4,56 +4,57 @@ import os
 
 from .inject import inject
 
-class GameServerProcess():
-  """
-  Standard game server process running in Windows
-  """
 
-  def __init__(
-    self, 
-    working_dir,
-    abslog,
-    port,
-    control_port,
-    dll_to_inject,
-    dll_config_path=None,
+class GameServerProcess():
+    """
+    Standard game server process running in Windows
+    """
+
+    def __init__(
+        self,
+        working_dir,
+        abslog,
+        port,
+        control_port,
+        dll_to_inject,
+        dll_config_path=None,
     ):
 
-    self.working_dir = working_dir
-    self.abslog = abslog
-    self.port = port
-    self.control_port = control_port
-    self.dll_to_inject = dll_to_inject
-    self.dll_config_path = dll_config_path
+        self.working_dir = working_dir
+        self.abslog = abslog
+        self.port = port
+        self.control_port = control_port
+        self.dll_to_inject = dll_to_inject
+        self.dll_config_path = dll_config_path
 
-  def start(self):
-    exe_path = os.path.join(self.working_dir, 'TribesAscend.exe')
-    args = [exe_path, 'server',
-      f'-abslog={self.abslog}',
-      f'-port={self.port}',
-      f'-controlport', str(self.control_port)
-    ]
+    def start(self):
+        exe_path = os.path.join(self.working_dir, 'TribesAscend.exe')
+        args = [exe_path, 'server',
+                f'-abslog={self.abslog}',
+                f'-port={self.port}',
+                f'-controlport', str(self.control_port)
+                ]
 
-    if self.dll_config_path is not None:
-      args.extend(['-tamodsconfig', self.dll_config_path])
+        if self.dll_config_path is not None:
+            args.extend(['-tamodsconfig', self.dll_config_path])
 
-    self.process = sp.Popen(args, cwd=self.working_dir)
-    self.pid = self.process.pid
+        self.process = sp.Popen(args, cwd=self.working_dir)
+        self.pid = self.process.pid
 
-  def poll(self):
-    return self.process.poll()
+    def poll(self):
+        return self.process.poll()
 
-  def wait(self):
-    return self.process.wait()
+    def wait(self):
+        return self.process.wait()
 
-  def terminate(self):
-    self.process.terminate()
+    def terminate(self):
+        self.process.terminate()
 
-  def freeze(self):
-    return ctypes.windll.kernel32.DebugActiveProcess(self.pid)
+    def freeze(self):
+        return ctypes.windll.kernel32.DebugActiveProcess(self.pid)
 
-  def unfreeze(self):
-    return ctypes.windll.kernel32.DebugActiveProcessStop(self.pid)
-  
-  def inject(self):
-    inject(self.process.pid, self.dll_to_inject)
+    def unfreeze(self):
+        return ctypes.windll.kernel32.DebugActiveProcessStop(self.pid)
+
+    def inject(self):
+        inject(self.process.pid, self.dll_to_inject)

--- a/game_server_launcher/main.py
+++ b/game_server_launcher/main.py
@@ -74,6 +74,7 @@ def main():
                 gevent_spawn("game server launcher's handle_game_server",
                              handle_game_server,
                              config['gameserver'],
+                             config['shared'],
                              ports,
                              server_handler_queue,
                              incoming_queue,

--- a/game_server_launcher/winegameserverprocess.py
+++ b/game_server_launcher/winegameserverprocess.py
@@ -1,0 +1,146 @@
+import gevent.subprocess as sp
+import os
+import signal
+import subprocess
+import time
+
+from common.errors import FatalError
+
+class WineGameServerProcess():
+  """
+  Manage a game server process running in linux using Wine (https://www.winehq.org/)
+  wine (32-bit) must be installed in the environment along with vcrun2017 from winetricks
+  """
+
+  def __init__(self,
+    working_dir,
+    abslog,
+    port,
+    control_port,
+    injector_path,
+    dll_to_inject,
+    dll_config_path=None,
+    wait_time_secs=5,
+    ):
+
+    self.working_dir = working_dir
+    self.abslog = abslog
+    self.port = port
+    self.control_port = control_port
+    self.dll_to_inject = dll_to_inject
+    self.dll_config_path = dll_config_path
+    self.wait_time_secs = int(wait_time_secs)
+    self.tribes_exe = os.path.join(self.working_dir, f'TribesAscend{self.port}.exe')
+    self.injector_path = injector_path
+
+  def start(self):
+    # Create hard link TribesAscend.exe -> TribesAscend<port>.exe 
+    # We use winedbg to find the wpid of the process, but winedbg does not show the cli args, only the exe.
+    # By creating an exe with the port in the name, we can identify and inject the right process.
+    if not os.path.exists(self.tribes_exe):
+      print(f"Creating link for {self.tribes_exe}")
+      os.link(os.path.join(self.working_dir, 'TribesAscend.exe'), self.tribes_exe)
+
+    # Starting with wineconsole instead of wine saves > 300MB of memory
+    args = ['wineconsole', self.tribes_exe, 'server',
+      f'-abslog={self.abslog}',
+      f'-port={self.port}',
+      f'-controlport', str(self.control_port),
+      '-noportoffset'
+    ]
+
+    if self.dll_config_path is not None:
+      args.extend(['-tamodsconfig', self.dll_config_path])
+
+    print(f"Starting game server with command: {args}")
+    self.process = sp.Popen(args, cwd=self.working_dir)
+
+    self.pid = None # PID is the wine PID. We need to use this for DLL injection
+    self.upid = None  # UPID is unix PID, which we need to use for freeze/unfreeze
+
+    # sometimes the wine process does not get shown immediately
+    # poll until we see it
+    start_time = time.time()
+    while time.time() < start_time + self.wait_time_secs:
+      if self.pid is None:
+        self.pid = self._find_tribes_windows_pid()
+      if self.upid is None:
+        self.upid = self._find_tribes_linux_pid()
+      if self.upid and self.upid:
+        break
+
+      time.sleep(1)
+
+    if self.pid is None:
+      raise FatalError(f'Failed to find wpid of game server process: {args}')
+
+    if self.upid is None:
+      raise FatalError(f'Failed to find upid of game server process: {args}')
+
+  def poll(self):
+    return self.process.poll()
+
+  def wait(self):
+    return self.process.wait()
+
+  def terminate(self):
+    self.process.terminate()
+
+  def freeze(self):
+    os.kill(self.upid, signal.SIGSTOP)
+    return True
+
+  def unfreeze(self):
+    os.kill(self.upid, signal.SIGCONT)
+    return True
+
+  def _find_tribes_linux_pid(self):
+    """
+    Finds the unix process id (upid) of TribesAscend.exe. Because we launched with wineconsole,
+    the actual game process (TribesAscend.exe) will be a child of it, so we need to use its pid 
+    instead of wineconsole's to freeze/unfreeze the game server.
+    https://man7.org/linux/man-pages/man5/proc.5.html
+    """
+    for pid in os.listdir('/proc'):
+      if pid.isdigit():
+        try:
+          with open(os.path.join('/proc', pid, 'cmdline')) as cmd:
+            if cmd.read().startswith(self.tribes_exe):
+              print(f"Found {self.tribes_exe} in /proc/{pid}")
+              return int(pid)
+        except Exception as e:
+         pass
+    print(f"Did not find {self.tribes_exe} in /proc")
+    return None
+
+  def _find_tribes_windows_pid(self):
+    """
+    Finds the windows process id (wpid) of TribesAscend.exe running in wine. The matching process's
+    command must also match the server id since there will be at least two TribesAscend.exe's running.
+    InjectorStandalone.exe must be supplied with the wpid, not the linux pid (upid) to find the
+    process when running under wine.
+    https://wiki.winehq.org/Wine_Developer%27s_Guide/Debugging_Wine#Processes_and_threads:_in_underlying_OS_and_in_Windows
+    """
+
+    # list wine processes
+    wine_pids = subprocess.check_output(['winedbg', '--command', 'info proc']).decode('utf-8')
+    print(wine_pids)
+    # find process for TribesAscend.exe which matches the port number
+    for line in wine_pids.split('\n'):
+      if f'TribesAscend' in line and str(self.port) in line:
+        # First column in line is wpid
+        return int(line.strip().split(' ')[0], 16)
+  
+
+  def inject(self):
+    """
+    Uses the InjectorStandalone.exe from https://github.com/mcoot/TribesLauncherSharp to inject
+    TAMods-server into Tribes. This is used by WineGameServerProcess since python on linux can
+    not inject a dll into a windows process.
+    """
+    try:
+      args = ['wine', self.injector_path, str(self.pid), self.dll_to_inject]
+      print(f"Running injector {args}")
+      subprocess.call(args)
+    except subprocess.CalledProcessError as e:
+      print(f'{e}: {e.output}')

--- a/game_server_launcher/winegameserverprocess.py
+++ b/game_server_launcher/winegameserverprocess.py
@@ -6,141 +6,145 @@ import time
 
 from common.errors import FatalError
 
+
 class WineGameServerProcess():
-  """
-  Manage a game server process running in linux using Wine (https://www.winehq.org/)
-  wine (32-bit) must be installed in the environment along with vcrun2017 from winetricks
-  """
-
-  def __init__(self,
-    working_dir,
-    abslog,
-    port,
-    control_port,
-    injector_path,
-    dll_to_inject,
-    dll_config_path=None,
-    wait_time_secs=5,
-    ):
-
-    self.working_dir = working_dir
-    self.abslog = abslog
-    self.port = port
-    self.control_port = control_port
-    self.dll_to_inject = dll_to_inject
-    self.dll_config_path = dll_config_path
-    self.wait_time_secs = int(wait_time_secs)
-    self.tribes_exe = os.path.join(self.working_dir, f'TribesAscend{self.port}.exe')
-    self.injector_path = injector_path
-
-  def start(self):
-    # Create hard link TribesAscend.exe -> TribesAscend<port>.exe 
-    # We use winedbg to find the wpid of the process, but winedbg does not show the cli args, only the exe.
-    # By creating an exe with the port in the name, we can identify and inject the right process.
-    if not os.path.exists(self.tribes_exe):
-      print(f"Creating link for {self.tribes_exe}")
-      os.link(os.path.join(self.working_dir, 'TribesAscend.exe'), self.tribes_exe)
-
-    # Starting with wineconsole instead of wine saves > 300MB of memory
-    args = ['wineconsole', self.tribes_exe, 'server',
-      f'-abslog={self.abslog}',
-      f'-port={self.port}',
-      f'-controlport', str(self.control_port),
-      '-noportoffset'
-    ]
-
-    if self.dll_config_path is not None:
-      args.extend(['-tamodsconfig', self.dll_config_path])
-
-    print(f"Starting game server with command: {args}")
-    self.process = sp.Popen(args, cwd=self.working_dir)
-
-    self.pid = None # PID is the wine PID. We need to use this for DLL injection
-    self.upid = None  # UPID is unix PID, which we need to use for freeze/unfreeze
-
-    # sometimes the wine process does not get shown immediately
-    # poll until we see it
-    start_time = time.time()
-    while time.time() < start_time + self.wait_time_secs:
-      if self.pid is None:
-        self.pid = self._find_tribes_windows_pid()
-      if self.upid is None:
-        self.upid = self._find_tribes_linux_pid()
-      if self.upid and self.upid:
-        break
-
-      time.sleep(1)
-
-    if self.pid is None:
-      raise FatalError(f'Failed to find wpid of game server process: {args}')
-
-    if self.upid is None:
-      raise FatalError(f'Failed to find upid of game server process: {args}')
-
-  def poll(self):
-    return self.process.poll()
-
-  def wait(self):
-    return self.process.wait()
-
-  def terminate(self):
-    self.process.terminate()
-
-  def freeze(self):
-    os.kill(self.upid, signal.SIGSTOP)
-    return True
-
-  def unfreeze(self):
-    os.kill(self.upid, signal.SIGCONT)
-    return True
-
-  def _find_tribes_linux_pid(self):
     """
-    Finds the unix process id (upid) of TribesAscend.exe. Because we launched with wineconsole,
-    the actual game process (TribesAscend.exe) will be a child of it, so we need to use its pid 
-    instead of wineconsole's to freeze/unfreeze the game server.
-    https://man7.org/linux/man-pages/man5/proc.5.html
+    Manage a game server process running in linux using Wine (https://www.winehq.org/)
+    wine (32-bit) must be installed in the environment along with vcrun2017 from winetricks
     """
-    for pid in os.listdir('/proc'):
-      if pid.isdigit():
+
+    def __init__(self,
+                 working_dir,
+                 abslog,
+                 port,
+                 control_port,
+                 injector_path,
+                 dll_to_inject,
+                 dll_config_path=None,
+                 wait_time_secs=5,
+                 ):
+
+        self.working_dir = working_dir
+        self.abslog = abslog
+        self.port = port
+        self.control_port = control_port
+        self.dll_to_inject = dll_to_inject
+        self.dll_config_path = dll_config_path
+        self.wait_time_secs = int(wait_time_secs)
+        self.tribes_exe = os.path.join(
+            self.working_dir, f'TribesAscend{self.port}.exe')
+        self.injector_path = injector_path
+
+    def start(self):
+        # Create hard link TribesAscend.exe -> TribesAscend<port>.exe
+        # We use winedbg to find the wpid of the process, but winedbg does not show the cli args, only the exe.
+        # By creating an exe with the port in the name, we can identify and inject the right process.
+        if not os.path.exists(self.tribes_exe):
+            print(f"Creating link for {self.tribes_exe}")
+            os.link(os.path.join(self.working_dir,
+                    'TribesAscend.exe'), self.tribes_exe)
+
+        # Starting with wineconsole instead of wine saves > 300MB of memory
+        args = ['wineconsole', self.tribes_exe, 'server',
+                f'-abslog={self.abslog}',
+                f'-port={self.port}',
+                f'-controlport', str(self.control_port),
+                '-noportoffset'
+                ]
+
+        if self.dll_config_path is not None:
+            args.extend(['-tamodsconfig', self.dll_config_path])
+
+        print(f"Starting game server with command: {args}")
+        self.process = sp.Popen(args, cwd=self.working_dir)
+
+        self.pid = None  # PID is the wine PID. We need to use this for DLL injection
+        self.upid = None  # UPID is unix PID, which we need to use for freeze/unfreeze
+
+        # sometimes the wine process does not get shown immediately
+        # poll until we see it
+        start_time = time.time()
+        while time.time() < start_time + self.wait_time_secs:
+            if self.pid is None:
+                self.pid = self._find_tribes_windows_pid()
+            if self.upid is None:
+                self.upid = self._find_tribes_linux_pid()
+            if self.upid and self.upid:
+                break
+
+            time.sleep(1)
+
+        if self.pid is None:
+            raise FatalError(
+                f'Failed to find wpid of game server process: {args}')
+
+        if self.upid is None:
+            raise FatalError(
+                f'Failed to find upid of game server process: {args}')
+
+    def poll(self):
+        return self.process.poll()
+
+    def wait(self):
+        return self.process.wait()
+
+    def terminate(self):
+        self.process.terminate()
+
+    def freeze(self):
+        os.kill(self.upid, signal.SIGSTOP)
+        return True
+
+    def unfreeze(self):
+        os.kill(self.upid, signal.SIGCONT)
+        return True
+
+    def _find_tribes_linux_pid(self):
+        """
+        Finds the unix process id (upid) of TribesAscend.exe. Because we launched with wineconsole,
+        the actual game process (TribesAscend.exe) will be a child of it, so we need to use its pid 
+        instead of wineconsole's to freeze/unfreeze the game server.
+        https://man7.org/linux/man-pages/man5/proc.5.html
+        """
+        for pid in os.listdir('/proc'):
+            if pid.isdigit():
+                try:
+                    with open(os.path.join('/proc', pid, 'cmdline')) as cmd:
+                        if cmd.read().startswith(self.tribes_exe):
+                            print(f"Found {self.tribes_exe} in /proc/{pid}")
+                            return int(pid)
+                except Exception as e:
+                    pass
+        print(f"Did not find {self.tribes_exe} in /proc")
+        return None
+
+    def _find_tribes_windows_pid(self):
+        """
+        Finds the windows process id (wpid) of TribesAscend.exe running in wine. The matching process's
+        command must also match the server id since there will be at least two TribesAscend.exe's running.
+        InjectorStandalone.exe must be supplied with the wpid, not the linux pid (upid) to find the
+        process when running under wine.
+        https://wiki.winehq.org/Wine_Developer%27s_Guide/Debugging_Wine#Processes_and_threads:_in_underlying_OS_and_in_Windows
+        """
+
+        # list wine processes
+        wine_pids = subprocess.check_output(['winedbg', '--command', 'info proc']).decode('utf-8')
+        print(wine_pids)
+        # find process for TribesAscend.exe which matches the port number
+        for line in wine_pids.split('\n'):
+            if f'TribesAscend' in line and str(self.port) in line:
+                # First column in line is wpid
+                return int(line.strip().split(' ')[0], 16)
+
+    def inject(self):
+        """
+        Uses the InjectorStandalone.exe from https://github.com/mcoot/TribesLauncherSharp to inject
+        TAMods-server into Tribes. This is used by WineGameServerProcess since python on linux can
+        not inject a dll into a windows process.
+        """
         try:
-          with open(os.path.join('/proc', pid, 'cmdline')) as cmd:
-            if cmd.read().startswith(self.tribes_exe):
-              print(f"Found {self.tribes_exe} in /proc/{pid}")
-              return int(pid)
-        except Exception as e:
-         pass
-    print(f"Did not find {self.tribes_exe} in /proc")
-    return None
-
-  def _find_tribes_windows_pid(self):
-    """
-    Finds the windows process id (wpid) of TribesAscend.exe running in wine. The matching process's
-    command must also match the server id since there will be at least two TribesAscend.exe's running.
-    InjectorStandalone.exe must be supplied with the wpid, not the linux pid (upid) to find the
-    process when running under wine.
-    https://wiki.winehq.org/Wine_Developer%27s_Guide/Debugging_Wine#Processes_and_threads:_in_underlying_OS_and_in_Windows
-    """
-
-    # list wine processes
-    wine_pids = subprocess.check_output(['winedbg', '--command', 'info proc']).decode('utf-8')
-    print(wine_pids)
-    # find process for TribesAscend.exe which matches the port number
-    for line in wine_pids.split('\n'):
-      if f'TribesAscend' in line and str(self.port) in line:
-        # First column in line is wpid
-        return int(line.strip().split(' ')[0], 16)
-  
-
-  def inject(self):
-    """
-    Uses the InjectorStandalone.exe from https://github.com/mcoot/TribesLauncherSharp to inject
-    TAMods-server into Tribes. This is used by WineGameServerProcess since python on linux can
-    not inject a dll into a windows process.
-    """
-    try:
-      args = ['wine', self.injector_path, str(self.pid), self.dll_to_inject]
-      print(f"Running injector {args}")
-      subprocess.call(args)
-    except subprocess.CalledProcessError as e:
-      print(f'{e}: {e.output}')
+            args = ['wine', self.injector_path, str(self.pid), self.dll_to_inject]
+            print(f"Running injector {args}")
+            subprocess.call(args)
+        except subprocess.CalledProcessError as e:
+            print(f'{e}: {e.output}')


### PR DESCRIPTION
changes:
- move process handling into GameServerProcess class
- implement WineGameServerProcess for linux
- add script to download InjectorStandalone.exe from TribesLauncherSharp

Tested on windows & linux (ubuntu 20.04)