### PR TITLE
send player display name on server join

### DIFF
--- a/common/messages.py
+++ b/common/messages.py
@@ -129,12 +129,13 @@ class Login2LauncherProtocolVersionMessage(Message):
         self.version = version
 
 
-# Example json: { 'unique_id' : 123, 'ip' : '1.2.3.4', 'eligible_for_first_win': false }
+# Example json: { 'unique_id' : 123, 'display_name': 'playername' 'ip' : '1.2.3.4', 'eligible_for_first_win': false }
 class Login2LauncherAddPlayer(Message):
     msg_id = _MSGID_LOGIN2LAUNCHER_ADD_PLAYER
 
-    def __init__(self, unique_id: int, ip: str, rank_xp: int, eligible_for_first_win: bool):
+    def __init__(self, unique_id: int, display_name: str, ip: str, rank_xp: int, eligible_for_first_win: bool):
         self.unique_id = unique_id
+        self.display_name = display_name
         self.ip = ip
         self.rank_xp = rank_xp
         self.eligible_for_first_win = eligible_for_first_win

--- a/common/versions.py
+++ b/common/versions.py
@@ -22,4 +22,4 @@ from distutils.version import StrictVersion
 
 # These versions must follow the MAJOR.MINOR.PATCH format of SemVer (https://semver.org/)
 launcher2controller_protocol_version = StrictVersion('5.0.0')
-launcher2loginserver_protocol_version = StrictVersion('10.0.0')
+launcher2loginserver_protocol_version = StrictVersion('11.0.0')

--- a/game_server_launcher/launcher.py
+++ b/game_server_launcher/launcher.py
@@ -295,7 +295,6 @@ class Launcher:
 
     def handle_remove_player_message(self, msg):
         if msg.ip:
-            display_name = msg.display_name
             self.logger.info('launcher: login server removed player %d with ip %s' % (msg.unique_id, msg.ip))
             self.firewall.modify_firewall('whitelist', 'remove', msg.unique_id, msg.ip)
         else:

--- a/game_server_launcher/launcher.py
+++ b/game_server_launcher/launcher.py
@@ -277,7 +277,7 @@ class Launcher:
 
     def handle_add_player_message(self, msg):
         if msg.ip:
-            self.logger.info('launcher: login server added player %d with ip %s' % (msg.unique_id, msg.ip))
+            self.logger.info('launcher: login server added player %d (%s) with ip %s' % (msg.unique_id, msg.display_name, msg.ip))
             self.firewall.modify_firewall('whitelist', 'add', msg.unique_id, msg.ip)
         else:
             self.logger.info('launcher: login server added local player %d' % msg.unique_id)
@@ -295,6 +295,7 @@ class Launcher:
 
     def handle_remove_player_message(self, msg):
         if msg.ip:
+            display_name = msg.display_name
             self.logger.info('launcher: login server removed player %d with ip %s' % (msg.unique_id, msg.ip))
             self.firewall.modify_firewall('whitelist', 'remove', msg.unique_id, msg.ip)
         else:

--- a/login_server/gameserver.py
+++ b/login_server/gameserver.py
@@ -174,6 +174,7 @@ class GameServer(Peer):
         player.vote = None
         player_ip = player.address_pair.get_address_seen_from(self.address_pair)
         msg = Login2LauncherAddPlayer(player.unique_id,
+                                      player.display_name,
                                       str(player_ip) if player_ip is not None else '',
                                       player.player_settings.progression.rank_xp,
                                       player.player_settings.progression.is_eligible_for_first_win())


### PR DESCRIPTION
Small update to send player name in the `Login2LauncherAddPlayer` message on server join. This is only used for logging. On the game server side, it will be much easier to debug issues and catch abuse if we can associate players & ip. 

This will require updating all game servers since the protocol is changing.