### PR TITLE
Game server setup instructions for linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ To talk about this project or request help, join the [discord server](https://di
 
 Select any of the topics below if you want to know more about it:
 * [How to join games](docs/user_manual/joining_games.md)
-* [How to host a game server](docs/user_manual/hosting_a_game_server.md) ([or two](docs/user_manual/hosting_multiple_game_servers.md))
+* [How to host a game server](docs/user_manual/hosting_a_game_server.md) ([or two](docs/user_manual/hosting_multiple_game_servers.md)) ([or on linux](docs/user_manual/hosting_a_game_server_linux.md))
 * [How to host a login server](docs/user_manual/hosting_a_login_server.md)
 
 If you encounter bugs or features that don't work yet, feel free

--- a/common/firewall.py
+++ b/common/firewall.py
@@ -18,11 +18,13 @@
 # along with taserver.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from gevent import socket
-from ipaddress import IPv4Address
 import json
 import logging
+import os
 import struct
+from ipaddress import IPv4Address
+
+from gevent import socket
 
 from .tcpmessage import TcpMessageWriter
 
@@ -31,7 +33,7 @@ class FirewallClient:
     def __init__(self, ports, shared_config):
         self.ports = ports
         # don't try to send commands to udpproxy if its not running
-        platform = shared_config.get('platform', 'windows')
+        platform = 'windows' if os.name == 'nt' else 'linux'
         self.use_udpproxy = (platform == 'windows')
 
     def _send_command(self, command):

--- a/data/gameserverlauncher.ini
+++ b/data/gameserverlauncher.ini
@@ -11,6 +11,6 @@ controller_config = gamesettings/ootb/serverconfig.lua
 # and replace the controller_config setting above with this one:
 #   controller_config = gamesettings\gotylike\serverconfig.lua
 
-# To launch with wine, add these lines to [gameserver]
-# Run download_injector.py to get the latest InjectorStandalone.exe
-# injector_exe = InjectorStandalone.exe
+# injector_exe is only used when the host OS is linux
+# If running on linux, run download_injector.py to get the latest InjectorStandalone.exe
+injector_exe = InjectorStandalone.exe

--- a/data/gameserverlauncher.ini
+++ b/data/gameserverlauncher.ini
@@ -5,7 +5,7 @@ port = 9001
 [gameserver]
 dir = C:\Games\Tribes_Ascend_Parting_Gifts\Binaries\Win32
 controller_dll = TAMods-Server.dll
-controller_config = gamesettings\ootb\serverconfig.lua
+controller_config = gamesettings/ootb/serverconfig.lua
 
 # To run a GOTY server you should run the download_gotylike.py script
 # and replace the controller_config setting above with this one:

--- a/data/shared.ini
+++ b/data/shared.ini
@@ -1,6 +1,2 @@
 [shared]
 port_offset = 0
-
-# Linux support:
-# use iptables instead of the windows firewall, disables udpproxy
-# platform = linux

--- a/docs/user_manual/hosting_a_game_server_linux.md
+++ b/docs/user_manual/hosting_a_game_server_linux.md
@@ -75,8 +75,7 @@ $ mv $(ls | grep taserver-*) taserver && rm taserver.zip
 
 ### Edit `taserver/data/gameserverlauncher.ini` as follows:
 
-- update `dir = /home/$USER/tribes/Tribes_Ascend_Parting_Gifts/Binaries/Win32` where $USER is your username
-- uncomment the line `injector_exe = InjectorStandalone.exe` under the `[gameserver]` section
+Update `dir = /home/$USER/tribes/Tribes_Ascend_Parting_Gifts/Binaries/Win32` where `$USER` is your username
 
 `gameserverlauncher.ini` should look like this
 ```
@@ -91,16 +90,6 @@ controller_config = gamesettings/ootb/serverconfig.lua
 injector_exe = InjectorStandalone.exe
 ```
 
-### Edit `taserver/data/shared.ini`
-
-Uncomment the line `platform = linux` under the `[shared]` section.
-
-`shared.ini` should look like:
-```
-[shared]
-port_offset = 0
-platform = linux
-```
 
 ## Download TAMods-Server and InjectorStandalone:
 

--- a/docs/user_manual/hosting_a_game_server_linux.md
+++ b/docs/user_manual/hosting_a_game_server_linux.md
@@ -1,0 +1,128 @@
+# Running taserver on Linux
+
+## Ports
+To make the server available publicly, you will have to open the following ports in your firewall or security group.
+
+  -   7777/UDP
+  -   7777/TCP
+  -   7778/UDP
+  -   7778/TCP
+  -   9002/UDP
+
+If the game server is running behind a router, you'll need to forward the above ports as well.
+
+# Option 1: Docker
+
+The simplest way to get a game server running on linux is to use the pre-built taserver-docker image.
+See 
+[chickenbellyfin/taserver on Docker Hub](https://hub.docker.com/r/chickenbellyfin/taserver) for full details.
+
+Install docker and then run:
+```
+docker run \
+  --name "taserver" -d --cap-add NET_ADMIN \
+  -v "$(pwd)/gamesettings:/gamesettings" -p "9002:9002/tcp" \
+  -p "7777:7777/tcp" -p "7777:7777/udp" \
+  -p "7778:7778/tcp" -p "7778:7778/udp" \
+  chickenbellyfin/taserver
+```
+
+
+# Option 2: Manual Setup
+
+These instructions are if you would like to install and run taserver directly without using docker. The steps are specific to debian/ubuntu but it should be possible to use a different distribution as well.
+
+## Install wine, python and other dependencies
+Wine is used to run windows programs (Tribes Ascend) on linux. Python is required to run taserver. This step may take a long time.
+```
+$ sudo dpkg --add-architecture i386
+$ sudo apt-get update
+$ sudo apt-get install -y wine winetricks python3 python3-pip unzip
+$ WINEARCH=win32 winetricks -q vcrun2017 dotnet48
+$ sudo pip install gevent certifi
+```
+
+## Headless only: install xvfb
+You only need this step if you are on a machine without a display, such as a server
+
+```
+$ sudo apt-get install xvfb
+$ Xvfb :1 &> xvfb.out & export DISPLAY=":1"
+```
+
+
+## Make a `tribes` directory to keep everything in
+```
+$ mkdir /home/$USER/tribes && cd /home/$USER/tribes
+```
+
+## Download Tribes_Ascend_Parting_Gifts.zip and extract it to /home/$USER/tribes/Tribes_Ascend_Parting_Gifts/
+[Tribes_Ascend_Parting_Gifts.zip download link](https://drive.google.com/uc?id=1hsjXFWJ2yvBCPNAy8SxQ2hT3XLIPvsrE&export=download)
+
+## Download the latest release of taserver
+
+```
+$ cd /home/$USER/tribes
+
+# Check https://github.com/Griffon26/taserver/releases and replace the TAG with the newest version
+$ TAG="v2.8.0"
+$ wget -O taserver.zip https://github.com/Griffon26/taserver/archive/refs/tags/$TAG.zip
+$ unzip -q taserver.zip
+$ mv $(ls | grep taserver-*) taserver && rm taserver.zip
+```
+
+## Update taserver configuration for linux
+
+### Edit `taserver/data/gameserverlauncher.ini` as follows:
+
+- update `dir = /home/$USER/tribes/Tribes_Ascend_Parting_Gifts/Binaries/Win32` where $USER is your username
+- uncomment the line `injector_exe = InjectorStandalone.exe` under the `[gameserver]` section
+
+`gameserverlauncher.ini` should look like this
+```
+[loginserver]
+host = ta.kfk4ever.com
+port = 9001
+
+[gameserver]
+dir = /home/<user>/tribes/Tribes_Ascend_Parting_Gifts/Binaries/Win32
+controller_dll = TAMods-Server.dll
+controller_config = gamesettings/ootb/serverconfig.lua
+injector_exe = InjectorStandalone.exe
+```
+
+### Edit `taserver/data/shared.ini`
+
+Uncomment the line `platform = linux` under the `[shared]` section.
+
+`shared.ini` should look like:
+```
+[shared]
+port_offset = 0
+platform = linux
+```
+
+## Download TAMods-Server and InjectorStandalone:
+
+```
+$ cd /home/$USER/tribes/taserver
+$ python3 download_compatible_controller.py
+$ python3 download_injector.py
+```
+
+## Launch firewall and game_server_launcher
+Run these steps every time you want to start the server.
+
+```
+$ cd /home/$USER/tribes/taserver
+
+# If you installed xvfb in the earlier previous step, run it in the background
+$ pkill Xvfb
+$ Xvfb :1 &> xvfb.out & export DISPLAY=":1"
+
+# start firewall and game server launcher
+$ sudo python3 start_taserver_firewall.py &> /dev/null &
+$ python3 start_game_server_launcher.py
+```
+
+

--- a/firewall/main.py
+++ b/firewall/main.py
@@ -19,20 +19,22 @@
 #
 import argparse
 import configparser
+import json
+import os
+import sys
+
 import gevent
 import gevent.queue
-from gevent.server import StreamServer
 import gevent.subprocess as sp
-import json
-import sys
+from gevent.server import StreamServer
 
 from common.geventwrapper import gevent_spawn
 from common.ports import Ports
 from common.tcpmessage import TcpMessageReader
 from common.utils import get_shared_ini_path
 
-from .windows_firewall import Firewall
 from .iptables_firewall import IPTablesFirewall
+from .windows_firewall import Firewall
 
 
 def main():
@@ -54,7 +56,8 @@ def main():
         ports = Ports(int(args.port_offset))
     else:
         ports = Ports(int(config['shared']['port_offset']))
-    platform = config['shared'].get('platform', 'windows')
+    platform = 'windows' if os.name == 'nt' else 'linux'
+    print(f"Detected platform as {platform}")
     use_iptables = (platform == 'linux')
     udpproxy_enabled = (platform == 'windows')
 

--- a/game_server_launcher/gameserverhandler.py
+++ b/game_server_launcher/gameserverhandler.py
@@ -75,7 +75,8 @@ class GameServerHandler:
             self.working_dir = game_server_config['dir']
             self.dll_to_inject = game_server_config['controller_dll']
             self.dll_config_path = os.path.join(data_root, game_server_config['controller_config'])
-            self.platform = shared_config.get('platform', 'windows')
+            self.platform = 'windows' if os.name == 'nt' else 'linux'
+            self.logger.info(f"Detected platform as {self.platform}")
             if self.platform == 'linux':
                 self.injector_exe = game_server_config['injector_exe']
         except KeyError as e:

--- a/game_server_launcher/gameserverhandler.py
+++ b/game_server_launcher/gameserverhandler.py
@@ -104,7 +104,9 @@ class GameServerHandler:
         if not os.path.exists(self.dll_config_path):
             raise ConfigurationError(
                 "Invalid 'controller_config' specified under [gameserver]: the specified file does not exist")
-
+        if self.platform == 'linux' and not os.path.exists(self.injector_exe):
+            raise ConfigurationError(
+                "Invalid 'injector_exe' specified under [gameserver]: the specified file does not exist")
 
     def wait_until_file_contains_string(self, filename, string, timeout = 0):
         i = 0


### PR DESCRIPTION
Added 2 options for launching game servers on linux. The first is using the docker container from the [taserver-docker](https://github.com/chickenbellyfin/taserver-docker) repo, and the second is the manual setup instructions.

Tested working on a new ubuntu 20.04 VM on azure.